### PR TITLE
Feature/#50

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,10 @@ deploy-sproc-prediction:
 deploy-sproc-training:
 	${POETRY_RUN} python src/pipelines/sproc_training.py
 
-deploy-sproc: deploy-sproc-dataset deploy-sproc-prediction deploy-sproc-training
+deploy-sproc-offline-testing:
+	${POETRY_RUN} python src/pipelines/sproc_offline_testing.py
+
+deploy-sproc: deploy-sproc-dataset deploy-sproc-prediction deploy-sproc-training deploy-sproc-offline-testing
 
 deploy-task-dataset:
 	${POETRY_RUN} python src/tasks/task_dataset.py
@@ -58,7 +61,10 @@ deploy-task-prediction:
 deploy-task-training:
 	${POETRY_RUN} python src/tasks/task_training.py
 
-deploy-task: deploy-task-dataset deploy-task-prediction deploy-task-training
+deploy-task-offline-testing:
+	${POETRY_RUN} python src/tasks/task_offline_testing.py
+
+deploy-task: deploy-task-dataset deploy-task-prediction deploy-task-training deploy-task-offline-testing	
 
 deploy-streamlit: __require_streamlit_app_name__
 	cd src/streamlit/${APP_NAME} && \

--- a/README.md
+++ b/README.md
@@ -14,12 +14,45 @@ The system predicts customer purchasing intent based on session data from an onl
 
 This setup simulates a marketing pipeline, enabling targeted campaigns based on intent scores.
 
-### Dataset
+## ML Sysmtem Details 
+
+### Data Flow
+
+#### Data Source
 The dataset used is a modified version of the [Online Shoppers Purchasing Intention Dataset](https://archive.ics.uci.edu/dataset/468/online+shoppers+purchasing+intention+dataset) from the UCI Machine Learning Repository. Modifications include:
 - `SessionDate`: Derived from the Month column and formatted as 2024-xx-01.
 - `UID`: Generated using UUIDs.
 
 By combining SessionDate and UID, each record in the dataset is uniquely identifiable. 
+
+#### Data pipeline
+
+1. Source Table (source)
+    - Stores raw data
+2. Dataset Table (dataset)
+    - Stores processed data for machine learning
+    - Contains feature-engineered data
+3. Scores Table (scores)
+    - Stores prediction results
+    - Contains UID, session date, model name, model version, and scores
+
+### Model Training Process 
+
+#### Challenger Model Generation (sproc_training)
+- Execution: 1st day of every month at 10:00 AM (JST)
+- Process Details:
+    - Model Training: Uses the last 3 months of data as train/val dataset
+    - Feature and hyperparameter search space configurations are managed in `src/config.yml`
+
+#### Model Evaluation & Update (sproc_model_evaluation)
+- Execution: 15th day of every month at 10:00 AM (JST)
+- Process Details:
+    - Model Evaluation: Uses the last 2 weeks of data (2 weeks after challenger model generation) as test dataset
+    - Model Update: Updates the production model if the challenger model outperforms the champion model
+
+### Model Inference Process 
+- Execution: Daily at 8:00 AM (JST)
+- Process Details: Predicts purchase intent scores for the previous day's data
 
 ## Technical Stack
 

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -2,9 +2,8 @@ import logging
 
 from snowflake.snowpark.session import Session
 
-from src.utils.config import load_config
+from src.utils.constants import DATABASE_DEV, DATASET, SCHEMA, SOURCE
 from src.utils.snowflake import upload_dataframe_to_snowflake
-from src.utils.constants import DATABASE_DEV, SCHEMA, DATASET, SOURCE
 
 logger = logging.getLogger(__name__)
 
@@ -30,17 +29,10 @@ def create_ml_dataset(
         source_table_name (str): ソーステーブル名
     """
     try:
-        config = load_config()
-        database_name = (
-            database_name
-            or session.get_current_database()
-            or DATABASE_DEV
-        )
+        database_name = database_name or session.get_current_database() or DATABASE_DEV
         schema_name = schema_name or SCHEMA
         table_name = table_name or DATASET
-        source_table_name = (
-            source_table_name or SOURCE
-        )
+        source_table_name = source_table_name or SOURCE
 
         logger.info(f"Starting dataset generation. Target date: {target_date}")
         gen_query = f"""

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -4,6 +4,7 @@ from snowflake.snowpark.session import Session
 
 from src.utils.config import load_config
 from src.utils.snowflake import upload_dataframe_to_snowflake
+from src.utils.constants import DATABASE_DEV, SCHEMA, DATASET, SOURCE
 
 logger = logging.getLogger(__name__)
 
@@ -33,12 +34,12 @@ def create_ml_dataset(
         database_name = (
             database_name
             or session.get_current_database()
-            or config["data"]["snowflake"]["database_dev"]
+            or DATABASE_DEV
         )
-        schema_name = schema_name or config["data"]["snowflake"]["schema"]
-        table_name = table_name or config["data"]["snowflake"]["dataset_table"]
+        schema_name = schema_name or SCHEMA
+        table_name = table_name or DATASET
         source_table_name = (
-            source_table_name or config["data"]["snowflake"]["source_table"]
+            source_table_name or SOURCE
         )
 
         logger.info(f"Starting dataset generation. Target date: {target_date}")

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -1,12 +1,11 @@
 import logging
-from typing import Optional
+from datetime import datetime
 
 import pandas as pd
-from snowflake.snowpark import Session
 from snowflake.ml.model import ModelVersion
+from snowflake.snowpark import Session
 
 from src.utils.config import load_config
-from datetime import datetime
 
 logger = logging.getLogger(__name__)
 config = load_config()
@@ -22,6 +21,7 @@ def _get_base_config():
     select_columns = ["UID"] + categorical_features + numerical_features + target
     return schema, table, select_columns
 
+
 def fetch_training_dataset(session: Session) -> pd.DataFrame:
     """学習用データセットを取得する関数
 
@@ -34,13 +34,17 @@ def fetch_training_dataset(session: Session) -> pd.DataFrame:
     try:
         schema, table, select_columns = _get_base_config()
         period_months = config["data"]["period"]["months"]
-        
+
         end_date = pd.Timestamp.now().strftime("%Y-%m-%d")
-        start_date = (pd.Timestamp.now() - pd.DateOffset(months=period_months)).strftime("%Y-%m-%d")
+        start_date = (
+            pd.Timestamp.now() - pd.DateOffset(months=period_months)
+        ).strftime("%Y-%m-%d")
         date_condition = f"SESSION_DATE BETWEEN '{start_date}' AND '{end_date}'"
-        
-        logger.info(f"Retrieving training data: period from {start_date} to {end_date} ({period_months} months)")
-        
+
+        logger.info(
+            f"Retrieving training data: period from {start_date} to {end_date} ({period_months} months)"
+        )
+
         query_string = f"""
             SELECT {', '.join(select_columns)} 
             FROM {schema}.{table}
@@ -56,7 +60,10 @@ def fetch_training_dataset(session: Session) -> pd.DataFrame:
 
     except Exception as e:
         logger.error(f"Error occurred during training dataset retrieval: {str(e)}")
-        raise RuntimeError(f"Error occurred during training dataset retrieval: {str(e)}")
+        raise RuntimeError(
+            f"Error occurred during training dataset retrieval: {str(e)}"
+        )
+
 
 def fetch_prediction_dataset(session: Session, prediction_date: str) -> pd.DataFrame:
     """推論用データセットを取得する関数
@@ -74,9 +81,9 @@ def fetch_prediction_dataset(session: Session, prediction_date: str) -> pd.DataF
 
         schema, table, select_columns = _get_base_config()
         date_condition = f"SESSION_DATE = '{prediction_date}'"
-        
+
         logger.info(f"Retrieving inference data for date: {prediction_date}")
-        
+
         query_string = f"""
             SELECT {', '.join(select_columns)} 
             FROM {schema}.{table}
@@ -92,11 +99,14 @@ def fetch_prediction_dataset(session: Session, prediction_date: str) -> pd.DataF
 
     except Exception as e:
         logger.error(f"Error occurred during prediction dataset retrieval: {str(e)}")
-        raise RuntimeError(f"Error occurred during prediction dataset retrieval: {str(e)}")
+        raise RuntimeError(
+            f"Error occurred during prediction dataset retrieval: {str(e)}"
+        )
+
 
 def fetch_test_dataset(session: Session, model_version: ModelVersion) -> pd.DataFrame:
     """テスト用データセットを取得する関数
-    
+
     Args:
         session (Session): Snowflakeセッション
         model_version (ModelVersion): 評価対象のモデルバージョン
@@ -106,18 +116,18 @@ def fetch_test_dataset(session: Session, model_version: ModelVersion) -> pd.Data
     """
     try:
         schema, table, select_columns = _get_base_config()
-        
+
         # モデルバージョンの作成日を取得
         model_version_name = model_version.version_name
-        model_created_date = datetime.strptime(f"20{model_version_name[2:8]}", '%Y%m%d')
-        
+        model_created_date = datetime.strptime(f"20{model_version_name[2:8]}", "%Y%m%d")
+
         # 評価期間の設定（モデル作成日から2週間）
         start_date = (model_created_date + pd.DateOffset(days=1)).strftime("%Y-%m-%d")
         end_date = (model_created_date + pd.DateOffset(days=14)).strftime("%Y-%m-%d")
         date_condition = f"SESSION_DATE BETWEEN '{start_date}' AND '{end_date}'"
-        
+
         logger.info(f"Retrieving testing data: period from {start_date} to {end_date}")
-        
+
         query_string = f"""
             SELECT {', '.join(select_columns)} 
             FROM {schema}.{table}

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -6,7 +6,13 @@ from snowflake.ml.model import ModelVersion
 from snowflake.snowpark import Session
 
 from src.utils.config import load_config
-from src.utils.constants import SCHEMA, DATASET, CATEGORICAL_FEATURES, NUMERICAL_FEATURES, TARGET
+from src.utils.constants import (
+    CATEGORICAL_FEATURES,
+    DATASET,
+    NUMERICAL_FEATURES,
+    SCHEMA,
+    TARGET,
+)
 
 logger = logging.getLogger(__name__)
 config = load_config()

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import pandas as pd
 from snowflake.snowpark import Session
-from snowflake.ml.registry import ModelVersion
+from snowflake.ml.model import ModelVersion
 
 from src.utils.config import load_config
 from datetime import datetime
@@ -109,7 +109,7 @@ def fetch_test_dataset(session: Session, model_version: ModelVersion) -> pd.Data
         
         # モデルバージョンの作成日を取得
         model_version_name = model_version.version_name
-        model_created_date = datetime.strptime(model_version_name[2:8], '%y%m%d')
+        model_created_date = datetime.strptime(f"20{model_version_name[2:8]}", '%Y%m%d')
         
         # 評価期間の設定（モデル作成日から2週間）
         start_date = (model_created_date + pd.DateOffset(days=1)).strftime("%Y-%m-%d")

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -6,6 +6,7 @@ from snowflake.ml.model import ModelVersion
 from snowflake.snowpark import Session
 
 from src.utils.config import load_config
+from src.utils.constants import SCHEMA, DATASET, CATEGORICAL_FEATURES, NUMERICAL_FEATURES, TARGET
 
 logger = logging.getLogger(__name__)
 config = load_config()
@@ -13,13 +14,8 @@ config = load_config()
 
 def _get_base_config():
     """基本設定を取得する内部関数"""
-    schema = config["data"]["snowflake"]["schema"]
-    table = config["data"]["snowflake"]["dataset_table"]
-    categorical_features = config["data"]["features"]["categorical"]
-    numerical_features = config["data"]["features"]["numeric"]
-    target = config["data"]["target"]
-    select_columns = ["UID"] + categorical_features + numerical_features + target
-    return schema, table, select_columns
+    select_columns = ["UID"] + CATEGORICAL_FEATURES + NUMERICAL_FEATURES + TARGET
+    return SCHEMA, DATASET, select_columns
 
 
 def fetch_training_dataset(session: Session) -> pd.DataFrame:

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -10,53 +10,35 @@ logger = logging.getLogger(__name__)
 config = load_config()
 
 
-def fetch_dataset(
-    session: Session, is_training: bool = True, prediction_date: Optional[str] = None
-) -> Optional[pd.DataFrame]:
-    """データセットを取得する関数
+def _get_base_config():
+    """基本設定を取得する内部関数"""
+    schema = config["data"]["snowflake"]["schema"]
+    table = config["data"]["snowflake"]["dataset_table"]
+    categorical_features = config["data"]["features"]["categorical"]
+    numerical_features = config["data"]["features"]["numeric"]
+    target = config["data"]["target"]
+    select_columns = ["UID"] + categorical_features + numerical_features + target
+    return schema, table, select_columns
+
+def fetch_training_dataset(session: Session) -> pd.DataFrame:
+    """学習用データセットを取得する関数
 
     Args:
         session (Session): Snowflakeセッション
-        is_training (bool): 学習時かどうかのフラグ。デフォルトはTrue
-        prediction_date (str): 推論日付（YYYY-MM-DD）
 
     Returns:
-        Optional[pd.DataFrame]: 取得したデータフレーム。エラー時はNone
+        pd.DataFrame: 取得したデータフレーム
     """
-
     try:
-        # config からデータセットの設定を取得
-        schema = config["data"]["snowflake"]["schema"]
-        table = config["data"]["snowflake"]["dataset_table"]
-        categorical_features = config["data"]["features"]["categorical"]
-        numerical_features = config["data"]["features"]["numeric"]
-        target = config["data"]["target"]
-
-        logger.info(f"Starting dataset retrieval from {schema}.{table}")
-        select_columns = ["UID"] + categorical_features + numerical_features + target
-
-        # 学習時と推論時で日付条件を分岐
-        if is_training:
-            period_months = config["data"]["period"][
-                "months"
-            ]  # 期間（月数）を設定から取得
-            # 現在の日付から指定された月数前までの期間を設定
-            end_date = pd.Timestamp.now().strftime("%Y-%m-%d")
-            start_date = (
-                pd.Timestamp.now() - pd.DateOffset(months=period_months)
-            ).strftime("%Y-%m-%d")
-            date_condition = f"SESSION_DATE BETWEEN '{start_date}' AND '{end_date}'"
-            logger.info(
-                f"Retrieving training data: period from {start_date} to {end_date} ({period_months} months)"
-            )
-        else:
-            if prediction_date is None:
-                raise ValueError("prediction_date is required for inference")
-
-            # 推論時は引数の推論日付を条件にする
-            date_condition = f"SESSION_DATE = '{prediction_date}'"
-            logger.info(f"Retrieving inference data for date: '{prediction_date}'")
-
+        schema, table, select_columns = _get_base_config()
+        period_months = config["data"]["period"]["months"]
+        
+        end_date = pd.Timestamp.now().strftime("%Y-%m-%d")
+        start_date = (pd.Timestamp.now() - pd.DateOffset(months=period_months)).strftime("%Y-%m-%d")
+        date_condition = f"SESSION_DATE BETWEEN '{start_date}' AND '{end_date}'"
+        
+        logger.info(f"Retrieving training data: period from {start_date} to {end_date} ({period_months} months)")
+        
         query_string = f"""
             SELECT {', '.join(select_columns)} 
             FROM {schema}.{table}
@@ -67,11 +49,45 @@ def fetch_dataset(
         if len(df) == 0:
             raise ValueError("No data found for the specified period.")
 
-        # 取得成功時のログ
-        logger.info(f"Dataset retrieval completed: {len(df)} rows")
+        logger.info(f"Training dataset retrieval completed: {len(df)} rows")
         return df
 
     except Exception as e:
-        # エラー発生時のログ
-        logger.error(f"Error occurred during dataset retrieval: {str(e)}")
-        raise RuntimeError(f"Error occurred during dataset retrieval: {str(e)}")
+        logger.error(f"Error occurred during training dataset retrieval: {str(e)}")
+        raise RuntimeError(f"Error occurred during training dataset retrieval: {str(e)}")
+
+def fetch_prediction_dataset(session: Session, prediction_date: str) -> pd.DataFrame:
+    """推論用データセットを取得する関数
+
+    Args:
+        session (Session): Snowflakeセッション
+        prediction_date (str): 推論日付（YYYY-MM-DD）
+
+    Returns:
+        pd.DataFrame: 取得したデータフレーム
+    """
+    try:
+        if not prediction_date:
+            raise ValueError("prediction_date is required for inference")
+
+        schema, table, select_columns = _get_base_config()
+        date_condition = f"SESSION_DATE = '{prediction_date}'"
+        
+        logger.info(f"Retrieving inference data for date: {prediction_date}")
+        
+        query_string = f"""
+            SELECT {', '.join(select_columns)} 
+            FROM {schema}.{table}
+            WHERE {date_condition}
+        """
+        df = session.sql(query_string).to_pandas()
+
+        if len(df) == 0:
+            raise ValueError("No data found for the specified date.")
+
+        logger.info(f"Prediction dataset retrieval completed: {len(df)} rows")
+        return df
+
+    except Exception as e:
+        logger.error(f"Error occurred during prediction dataset retrieval: {str(e)}")
+        raise RuntimeError(f"Error occurred during prediction dataset retrieval: {str(e)}")

--- a/src/data/source.py
+++ b/src/data/source.py
@@ -6,9 +6,8 @@ import pandas as pd
 from snowflake.snowpark.session import Session
 from ucimlrepo import fetch_ucirepo
 
-from src.utils.config import load_config
-from src.utils.snowflake import upload_dataframe_to_snowflake
 from src.utils.constants import DATABASE_DEV, SCHEMA, SOURCE
+from src.utils.snowflake import upload_dataframe_to_snowflake
 
 logger = logging.getLogger(__name__)
 
@@ -80,12 +79,7 @@ def prepare_online_shoppers_data(
         Exception: データの取得中にエラーが発生した場合
     """
     try:
-        config = load_config()
-        database_name = (
-            database_name
-            or session.get_current_database()
-            or DATABASE_DEV
-        )
+        database_name = database_name or session.get_current_database() or DATABASE_DEV
         schema_name = schema_name or SCHEMA
         table_name = table_name or SOURCE
 

--- a/src/data/source.py
+++ b/src/data/source.py
@@ -8,6 +8,7 @@ from ucimlrepo import fetch_ucirepo
 
 from src.utils.config import load_config
 from src.utils.snowflake import upload_dataframe_to_snowflake
+from src.utils.constants import DATABASE_DEV, SCHEMA, SOURCE
 
 logger = logging.getLogger(__name__)
 
@@ -83,10 +84,10 @@ def prepare_online_shoppers_data(
         database_name = (
             database_name
             or session.get_current_database()
-            or config["data"]["snowflake"]["database_dev"]
+            or DATABASE_DEV
         )
-        schema_name = schema_name or config["data"]["snowflake"]["schema"]
-        table_name = table_name or config["data"]["snowflake"]["source_table"]
+        schema_name = schema_name or SCHEMA
+        table_name = table_name or SOURCE
 
         logger.info("Starting dataset retrieval")
         dataset = fetch_ucirepo(id=468)

--- a/src/models/predictor.py
+++ b/src/models/predictor.py
@@ -9,21 +9,9 @@ def load_latest_model_version(session: Session) -> ModelVersion:
     """
     最新のモデルバージョンを取得する
     """
-    # registry から最新のモデルを取得
     registry = Registry(session=session)
-    registered_models = registry.show_models().sort_values(
-        "created_on", ascending=False
-    )
-    latest_model_name = registered_models["name"].values[0]
-
-    # モデルの参照を取得
-    model_ref = registry.get_model(latest_model_name)
-
-    # 全バージョンを取得し、作成日で降順ソートして最新を選択
-    versions = model_ref.show_versions().sort_values("created_on", ascending=False)
-    latest_version = versions["name"].values[0]
-
-    mv = model_ref.version(latest_version)
+    model_ref = registry.get_model("random_forest")
+    mv = model_ref.last()
 
     return mv
 
@@ -38,10 +26,17 @@ def load_default_model_version(session: Session) -> ModelVersion:
     return mv
 
 
-def predict(features: pd.DataFrame, mv: ModelVersion) -> np.ndarray:
+def predict_proba(features: pd.DataFrame, mv: ModelVersion) -> np.ndarray:
     """
     モデルを用いて推論を行う
     """
     # run の結果は output_feature_0, output_feature_1 の2つの列を持つデータフレーム
     pred_probas_df = mv.run(features, function_name="predict_proba")
     return pred_probas_df.output_feature_1.values
+
+def predict_label(features: pd.DataFrame, mv: ModelVersion) -> np.ndarray:
+    """
+    モデルを用いて推論を行う
+    """
+    pred_df = mv.run(features, function_name="predict")
+    return pred_df.output_feature_0.values

--- a/src/models/predictor.py
+++ b/src/models/predictor.py
@@ -27,6 +27,15 @@ def load_latest_model_version(session: Session) -> ModelVersion:
 
     return mv
 
+def load_default_model_version(session: Session) -> ModelVersion:
+    """
+    デフォルトバージョンを取得する
+    """
+    registry = Registry(session=session)
+    model_ref = registry.get_model("random_forest")
+    mv = model_ref.default
+    return mv
+
 
 def predict(features: pd.DataFrame, mv: ModelVersion) -> np.ndarray:
     """

--- a/src/models/predictor.py
+++ b/src/models/predictor.py
@@ -34,6 +34,7 @@ def predict_proba(features: pd.DataFrame, mv: ModelVersion) -> np.ndarray:
     pred_probas_df = mv.run(features, function_name="predict_proba")
     return pred_probas_df.output_feature_1.values
 
+
 def predict_label(features: pd.DataFrame, mv: ModelVersion) -> np.ndarray:
     """
     モデルを用いて推論を行う

--- a/src/models/predictor.py
+++ b/src/models/predictor.py
@@ -27,6 +27,7 @@ def load_latest_model_version(session: Session) -> ModelVersion:
 
     return mv
 
+
 def load_default_model_version(session: Session) -> ModelVersion:
     """
     デフォルトバージョンを取得する

--- a/src/pipelines/sproc_dataset.py
+++ b/src/pipelines/sproc_dataset.py
@@ -6,9 +6,9 @@ from snowflake.snowpark import Session
 
 from src.data.dataset import update_ml_dataset
 from src.utils.config import load_config
+from src.utils.constants import DATABASE_DEV, DATASET, IMPORTS_DIR, SCHEMA, SOURCE
 from src.utils.logger import setup_logging
 from src.utils.snowflake import create_session
-from src.utils.constants import DATABASE_DEV, SCHEMA, DATASET, SOURCE, IMPORTS_DIR
 
 logger = logging.getLogger(__name__)
 

--- a/src/pipelines/sproc_dataset.py
+++ b/src/pipelines/sproc_dataset.py
@@ -8,17 +8,11 @@ from src.data.dataset import update_ml_dataset
 from src.utils.config import load_config
 from src.utils.logger import setup_logging
 from src.utils.snowflake import create_session
+from src.utils.constants import DATABASE_DEV, SCHEMA, DATASET, SOURCE, IMPORTS_DIR
 
 logger = logging.getLogger(__name__)
 
 config = load_config()
-DATABASE_DEV = config["data"]["snowflake"]["database_dev"]
-SCHEMA = config["data"]["snowflake"]["schema"]
-DATASET = config["data"]["snowflake"]["dataset_table"]
-SOURCE = config["data"]["snowflake"]["source_table"]
-
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-IMPORTS_DIR = os.path.join(BASE_DIR, "src")
 
 
 def sproc_dataset(session: Session, target_date: str) -> int:

--- a/src/pipelines/sproc_offline_testing.py
+++ b/src/pipelines/sproc_offline_testing.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import sys
-from datetime import datetime
 
 from snowflake.snowpark import Session
 
@@ -45,12 +44,9 @@ def sproc_offline_testing(session: Session) -> int:
         challenger_mv = load_latest_model_version(session)
 
         # テストデータの取得
-        
-
 
         # モデル比較
 
-        
         return 1
 
     except Exception as e:
@@ -85,7 +81,9 @@ if __name__ == "__main__":
             "execute_as": "caller",
         }
         session.sproc.register(func=sproc_offline_testing, **sproc_config)  # type: ignore
-        session.sql("ALTER PROCEDURE OFFLINE_TESTING() SET LOG_LEVEL = 'INFO'").collect()
+        session.sql(
+            "ALTER PROCEDURE OFFLINE_TESTING() SET LOG_LEVEL = 'INFO'"
+        ).collect()
 
     except Exception as e:
         print(f"An error occurred: {str(e)}")

--- a/src/pipelines/sproc_offline_testing.py
+++ b/src/pipelines/sproc_offline_testing.py
@@ -40,42 +40,58 @@ def sproc_offline_testing(session: Session) -> int:
     """
     try:
         setup_logging()
+        logger.info("Starting offline testing procedure")
 
         # Championモデルの取得（Defalutバージョン）
+        logger.info("Loading champion model (default version)")
         champion_mv = load_default_model_version(session)
+        logger.info(f"Champion model version: {champion_mv.version}")
 
         # Challengerモデルの取得（作成日が最新のバージョン）
+        logger.info("Loading challenger model (latest version)")
         challenger_mv = load_latest_model_version(session)
+        logger.info(f"Challenger model version: {challenger_mv.version}")
 
         # テストデータの取得
+        logger.info("Fetching test dataset")
         test_df = fetch_test_dataset(session, challenger_mv)
         TARGET_COL = config["data"]["target"][0]
         test_features = test_df.drop(columns=[TARGET_COL, "UID"])
         test_target = test_df[TARGET_COL]
+        logger.info(f"Test dataset size: {len(test_df)} rows")
 
         # モデル比較
+        logger.info("Starting model comparison")
         challenger_pred_proba = predict_proba(test_features, challenger_mv)
         champion_pred_proba = predict_proba(test_features, champion_mv)
         challenger_pred_label = predict_label(test_features, challenger_mv)
         champion_pred_label = predict_label(test_features, champion_mv)
+        
+        logger.info("Calculating evaluation metrics")
         challenger_scores = calc_evaluation_metrics(test_target, challenger_pred_label, challenger_pred_proba)
         champion_scores = calc_evaluation_metrics(test_target, champion_pred_label, champion_pred_proba)
+        
+        logger.info(f"Champion model scores: {champion_scores}")
+        logger.info(f"Challenger model scores: {challenger_scores}")
 
         if challenger_scores["PR-AUC"] > champion_scores["PR-AUC"]:
-            logger.info("Challenger model is better than Champion model. Updating default version.")
+            logger.info(f"Challenger model (PR-AUC: {challenger_scores['PR-AUC']:.4f}) is better than Champion model (PR-AUC: {champion_scores['PR-AUC']:.4f})")
+            logger.info("Updating default version to challenger model")
 
-            # default version を challenger に変更
             registry = Registry(session=session)
             m = registry.get_model("random_forest")
             m.default = challenger_mv
+            logger.info("Default version updated successfully")
 
         else:
-            logger.info("Champion model is better than Challenger model. No action is taken.")
+            logger.info(f"Champion model (PR-AUC: {champion_scores['PR-AUC']:.4f}) is better than Challenger model (PR-AUC: {challenger_scores['PR-AUC']:.4f})")
+            logger.info("No action taken")
 
+        logger.info("Offline testing completed successfully")
         return 1
 
     except Exception as e:
-        logger.error(f"An error occurred: {str(e)}")
+        logger.error(f"An error occurred during offline testing: {str(e)}", exc_info=True)
         raise e
 
 

--- a/src/pipelines/sproc_offline_testing.py
+++ b/src/pipelines/sproc_offline_testing.py
@@ -16,17 +16,10 @@ from src.models.trainer import calc_evaluation_metrics
 from src.utils.config import load_config
 from src.utils.logger import setup_logging
 from src.utils.snowflake import create_session
+from src.utils.constants import SCHEMA, IMPORTS_DIR
 
 logger = logging.getLogger(__name__)
-
 config = load_config()
-DATABASE_DEV = config["data"]["snowflake"]["database_dev"]
-SCHEMA = config["data"]["snowflake"]["schema"]
-DATASET = config["data"]["snowflake"]["dataset_table"]
-SOURCE = config["data"]["snowflake"]["source_table"]
-
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-IMPORTS_DIR = os.path.join(BASE_DIR, "src")
 
 
 def sproc_offline_testing(session: Session) -> int:

--- a/src/pipelines/sproc_offline_testing.py
+++ b/src/pipelines/sproc_offline_testing.py
@@ -1,0 +1,95 @@
+import logging
+import os
+import sys
+from datetime import datetime
+
+from snowflake.snowpark import Session
+
+from src.models.predictor import load_default_model_version, load_latest_model_version
+from src.utils.config import load_config
+from src.utils.logger import setup_logging
+from src.utils.snowflake import create_session
+
+logger = logging.getLogger(__name__)
+
+config = load_config()
+DATABASE_DEV = config["data"]["snowflake"]["database_dev"]
+SCHEMA = config["data"]["snowflake"]["schema"]
+DATASET = config["data"]["snowflake"]["dataset_table"]
+SOURCE = config["data"]["snowflake"]["source_table"]
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+IMPORTS_DIR = os.path.join(BASE_DIR, "src")
+
+
+def sproc_offline_testing(session: Session) -> int:
+    """
+    Challenger vs Champion モデルの評価
+
+    Args:
+        session (Session): Snowflakeセッション
+
+    Returns:
+        int: 成功時は1、失敗時は例外を発生
+
+    Raises:
+        Exception: 処理中にエラーが発生した場合
+    """
+    try:
+        setup_logging()
+
+        # Championモデルの取得（Defalutバージョン）
+        champion_mv = load_default_model_version(session)
+
+        # Challengerモデルの取得（作成日が最新のバージョン）
+        challenger_mv = load_latest_model_version(session)
+
+        # テストデータの取得
+        
+
+
+        # モデル比較
+
+        
+        return 1
+
+    except Exception as e:
+        logger.error(f"An error occurred: {str(e)}")
+        raise e
+
+
+if __name__ == "__main__":
+    try:
+        session = create_session()
+        if session is None:
+            raise RuntimeError("Failed to create Snowflake session")
+
+        stage_location = f"@{session.get_current_database()}.{SCHEMA}.sproc"
+        sproc_config = {
+            "name": "OFFLINE_TESTING",
+            "is_permanent": True,
+            "stage_location": stage_location,
+            "packages": [
+                "snowflake-snowpark-python",
+                "snowflake-ml-python",
+                "scikit-learn",
+            ],
+            "imports": [
+                (os.path.join(IMPORTS_DIR, "data"), "src.data"),
+                (os.path.join(IMPORTS_DIR, "models"), "src.models"),
+                (os.path.join(IMPORTS_DIR, "utils/config.py"), "src.utils.config"),
+                (os.path.join(IMPORTS_DIR, "utils/logger.py"), "src.utils.logger"),
+                os.path.join(IMPORTS_DIR, "config.yml"),
+            ],
+            "replace": True,
+            "execute_as": "caller",
+        }
+        session.sproc.register(func=sproc_offline_testing, **sproc_config)  # type: ignore
+        session.sql("ALTER PROCEDURE OFFLINE_TESTING() SET LOG_LEVEL = 'INFO'").collect()
+
+    except Exception as e:
+        print(f"An error occurred: {str(e)}")
+        sys.exit(1)
+    finally:
+        if session:
+            session.close()

--- a/src/pipelines/sproc_offline_testing.py
+++ b/src/pipelines/sproc_offline_testing.py
@@ -14,9 +14,9 @@ from src.models.predictor import (
 )
 from src.models.trainer import calc_evaluation_metrics
 from src.utils.config import load_config
+from src.utils.constants import IMPORTS_DIR, SCHEMA
 from src.utils.logger import setup_logging
 from src.utils.snowflake import create_session
-from src.utils.constants import SCHEMA, IMPORTS_DIR
 
 logger = logging.getLogger(__name__)
 config = load_config()

--- a/src/pipelines/sproc_prediction.py
+++ b/src/pipelines/sproc_prediction.py
@@ -7,9 +7,9 @@ from snowflake.snowpark import Session
 from src.data.loader import fetch_prediction_dataset
 from src.models.predictor import load_latest_model_version, predict_proba
 from src.utils.config import load_config
+from src.utils.constants import DATABASE_DEV, IMPORTS_DIR, SCHEMA
 from src.utils.logger import setup_logging
 from src.utils.snowflake import create_session, upload_dataframe_to_snowflake
-from src.utils.constants import DATABASE_DEV, SCHEMA, IMPORTS_DIR
 
 logger = logging.getLogger(__name__)
 

--- a/src/pipelines/sproc_prediction.py
+++ b/src/pipelines/sproc_prediction.py
@@ -5,7 +5,7 @@ import sys
 from snowflake.snowpark import Session
 
 from src.data.loader import fetch_prediction_dataset
-from src.models.predictor import load_latest_model_version, predict
+from src.models.predictor import load_latest_model_version, predict_proba
 from src.utils.config import load_config
 from src.utils.logger import setup_logging
 from src.utils.snowflake import create_session, upload_dataframe_to_snowflake
@@ -50,7 +50,7 @@ def sproc_prediction(session: Session, prediction_date: str = "2024-10-01") -> i
         mv = load_latest_model_version(session)
         logger.info("Model loading completed")
 
-        df["SCORE"] = predict(features, mv)
+        df["SCORE"] = predict_proba(features, mv)
         logger.info("Prediction completed")
 
         # 推論結果をスコアテーブルに書き込み

--- a/src/pipelines/sproc_prediction.py
+++ b/src/pipelines/sproc_prediction.py
@@ -9,17 +9,11 @@ from src.models.predictor import load_latest_model_version, predict_proba
 from src.utils.config import load_config
 from src.utils.logger import setup_logging
 from src.utils.snowflake import create_session, upload_dataframe_to_snowflake
+from src.utils.constants import DATABASE_DEV, SCHEMA, IMPORTS_DIR
 
 logger = logging.getLogger(__name__)
 
 config = load_config()
-DATABASE_DEV = config["data"]["snowflake"]["database_dev"]
-SCHEMA = config["data"]["snowflake"]["schema"]
-DATASET = config["data"]["snowflake"]["dataset_table"]
-SOURCE = config["data"]["snowflake"]["source_table"]
-
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-IMPORTS_DIR = os.path.join(BASE_DIR, "src")
 
 
 def sproc_prediction(session: Session, prediction_date: str = "2024-10-01") -> int:

--- a/src/pipelines/sproc_prediction.py
+++ b/src/pipelines/sproc_prediction.py
@@ -5,7 +5,7 @@ import sys
 from snowflake.snowpark import Session
 
 from src.data.loader import fetch_prediction_dataset
-from src.models.predictor import load_latest_model_version, predict_proba
+from src.models.predictor import load_default_model_version, predict_proba
 from src.utils.config import load_config
 from src.utils.constants import DATABASE_DEV, IMPORTS_DIR, SCHEMA
 from src.utils.logger import setup_logging
@@ -41,7 +41,7 @@ def sproc_prediction(session: Session, prediction_date: str = "2024-10-01") -> i
         features = df.drop(columns=["UID"])
         logger.info(f"Dataset fetched successfully. Number of rows: {len(df)}")
 
-        mv = load_latest_model_version(session)
+        mv = load_default_model_version(session)
         logger.info("Model loading completed")
 
         df["SCORE"] = predict_proba(features, mv)

--- a/src/pipelines/sproc_prediction.py
+++ b/src/pipelines/sproc_prediction.py
@@ -37,7 +37,7 @@ def sproc_prediction(session: Session, prediction_date: str = "2024-10-01") -> i
         Exception: 処理中にエラーが発生した場合
     """
     try:
-        setup_logging() 
+        setup_logging()
 
         logger.info(f"Starting prediction process, prediction_date={prediction_date}")
 

--- a/src/pipelines/sproc_prediction.py
+++ b/src/pipelines/sproc_prediction.py
@@ -4,7 +4,7 @@ import sys
 
 from snowflake.snowpark import Session
 
-from src.data.loader import fetch_dataset
+from src.data.loader import fetch_prediction_dataset
 from src.models.predictor import load_latest_model_version, predict
 from src.utils.config import load_config
 from src.utils.logger import setup_logging
@@ -37,11 +37,11 @@ def sproc_prediction(session: Session, prediction_date: str = "2024-10-01") -> i
         Exception: 処理中にエラーが発生した場合
     """
     try:
-        setup_logging()  # ロギング設定の初期化
+        setup_logging() 
 
         logger.info(f"Starting prediction process, prediction_date={prediction_date}")
 
-        df = fetch_dataset(session, is_training=False, prediction_date=prediction_date)
+        df = fetch_prediction_dataset(session, prediction_date=prediction_date)
         if df is None:
             raise ValueError("Failed to fetch dataset")
         features = df.drop(columns=["UID"])

--- a/src/pipelines/sproc_training.py
+++ b/src/pipelines/sproc_training.py
@@ -12,17 +12,11 @@ from src.models.trainer import calc_evaluation_metrics, train_model
 from src.utils.config import load_config
 from src.utils.logger import setup_logging
 from src.utils.snowflake import create_session
+from src.utils.constants import SCHEMA, IMPORTS_DIR
 
 logger = logging.getLogger(__name__)
 
 config = load_config()
-DATABASE_DEV = config["data"]["snowflake"]["database_dev"]
-SCHEMA = config["data"]["snowflake"]["schema"]
-DATASET = config["data"]["snowflake"]["dataset_table"]
-SOURCE = config["data"]["snowflake"]["source_table"]
-
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-IMPORTS_DIR = os.path.join(BASE_DIR, "src")
 
 
 def sproc_training(session: Session) -> int:

--- a/src/pipelines/sproc_training.py
+++ b/src/pipelines/sproc_training.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from snowflake.ml.registry import Registry
 from snowflake.snowpark import Session
 
-from src.data.loader import fetch_dataset
+from src.data.loader import fetch_training_dataset
 from src.data.preprocessing import split_data
 from src.models.trainer import calc_evaluation_metrics, train_model
 from src.utils.config import load_config
@@ -43,7 +43,7 @@ def sproc_training(session: Session) -> int:
 
         target_column = config["data"]["target"]
 
-        df = fetch_dataset(session, is_training=True)
+        df = fetch_training_dataset(session)
         if df is None:
             raise ValueError("Failed to fetch dataset")
         logger.info(f"Dataset fetched successfully. Number of rows: {len(df)}")

--- a/src/pipelines/sproc_training.py
+++ b/src/pipelines/sproc_training.py
@@ -86,6 +86,8 @@ def sproc_training(session: Session) -> int:
                 1
             ),  # サンプル入力データを追加
         )
+
+        # ToDo: 本当は新モデルには challenger タグをつけて管理したい（2025/02/14現在, タグは Enterprise以上でしか利用できない）
         logger.info("Model logging completed")
 
         return 1

--- a/src/pipelines/sproc_training.py
+++ b/src/pipelines/sproc_training.py
@@ -10,9 +10,9 @@ from src.data.loader import fetch_training_dataset
 from src.data.preprocessing import split_data
 from src.models.trainer import calc_evaluation_metrics, train_model
 from src.utils.config import load_config
+from src.utils.constants import IMPORTS_DIR, SCHEMA
 from src.utils.logger import setup_logging
 from src.utils.snowflake import create_session
-from src.utils.constants import SCHEMA, IMPORTS_DIR
 
 logger = logging.getLogger(__name__)
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,9 +5,9 @@ from snowflake.snowpark import Session
 
 from src.data.dataset import create_ml_dataset
 from src.data.source import prepare_online_shoppers_data
+from src.utils.constants import DATABASE_DEV, DATASET, SCHEMA, SOURCE
 from src.utils.logger import setup_logging
 from src.utils.snowflake import create_session
-from src.utils.constants import DATABASE_DEV, SCHEMA, SOURCE, DATASET
 
 logger = logging.getLogger(__name__)
 
@@ -16,19 +16,14 @@ def setup_environment(session: Session) -> None:
     try:
         setup_logging()
 
-        database_name = (
-            session.get_current_database()
-            or DATABASE_DEV
-        )
+        database_name = session.get_current_database() or DATABASE_DEV
 
         # データベースが存在しない場合は作成
         session.sql(f"CREATE DATABASE IF NOT EXISTS {database_name}").collect()
         logger.info(f"Ensured database {database_name} exists")
 
         # スキーマが存在しない場合は作成
-        session.sql(
-            f"CREATE SCHEMA IF NOT EXISTS {database_name}.{SCHEMA}"
-        ).collect()
+        session.sql(f"CREATE SCHEMA IF NOT EXISTS {database_name}.{SCHEMA}").collect()
         logger.info(f"Ensured schema {SCHEMA} exists in database {database_name}")
 
         # ソーステーブルを作成

--- a/src/tasks/task_offline_testing.py
+++ b/src/tasks/task_offline_testing.py
@@ -29,7 +29,7 @@ def create_offline_testing_task(session: Session) -> None:
             WAREHOUSE = COMPUTE_WH
             SCHEDULE = 'USING CRON 0 10 15 * * Asia/Tokyo'  -- 毎月15日の午前10時に実行
         AS
-            CALL {session.get_current_database()}.{session.get_current_schema()}.offline_testing();
+            CALL offline_testing();
         """
         session.sql(create_task_sql).collect()
         logger.info("Task created successfully")

--- a/src/tasks/task_offline_testing.py
+++ b/src/tasks/task_offline_testing.py
@@ -1,0 +1,60 @@
+import logging
+import sys
+
+from snowflake.snowpark import Session
+
+from src.utils.logger import setup_logging
+from src.utils.snowflake import create_session
+
+logger = logging.getLogger(__name__)
+
+
+def create_offline_testing_task(session: Session) -> None:
+    """
+    オフラインテスト用のストアドプロシージャを実行するタスクを作成する
+
+    Args:
+        session (Session): Snowflakeセッション
+
+    Raises:
+        Exception: タスクの作成に失敗した場合
+    """
+    try:
+        setup_logging()
+        logger.info("Starting offline testing task creation")
+
+        # タスクの作成
+        create_task_sql = f"""
+        CREATE OR REPLACE TASK task_offline_testing
+            WAREHOUSE = COMPUTE_WH
+            SCHEDULE = 'USING CRON 0 10 15 * * Asia/Tokyo'  -- 毎月15日の午前10時に実行
+        AS
+            CALL {session.get_current_database()}.{session.get_current_schema()}.offline_testing();
+        """
+        session.sql(create_task_sql).collect()
+        logger.info("Task created successfully")
+
+        # タスクの有効化
+        session.sql("ALTER TASK task_offline_testing RESUME").collect()
+        logger.info("Task resumed successfully")
+
+    except Exception as e:
+        error_msg = f"Failed to create offline testing task: {str(e)}"
+        logger.error(error_msg)
+        raise
+
+
+if __name__ == "__main__":
+    try:
+        session = create_session()
+        if session is None:
+            raise RuntimeError("Failed to create Snowflake session")
+
+        create_offline_testing_task(session)
+
+    except Exception as e:
+        print(f"An error occurred: {str(e)}")
+        sys.exit(1)
+    finally:
+        if session:
+            session.close() 

--- a/src/tasks/task_offline_testing.py
+++ b/src/tasks/task_offline_testing.py
@@ -24,7 +24,7 @@ def create_offline_testing_task(session: Session) -> None:
         logger.info("Starting offline testing task creation")
 
         # タスクの作成
-        create_task_sql = f"""
+        create_task_sql = """
         CREATE OR REPLACE TASK task_offline_testing
             WAREHOUSE = COMPUTE_WH
             SCHEDULE = 'USING CRON 0 10 15 * * Asia/Tokyo'  -- 毎月15日の午前10時に実行
@@ -57,4 +57,4 @@ if __name__ == "__main__":
         sys.exit(1)
     finally:
         if session:
-            session.close() 
+            session.close()

--- a/src/tasks/task_training.py
+++ b/src/tasks/task_training.py
@@ -29,7 +29,7 @@ def create_training_task(session: Session) -> None:
             WAREHOUSE = COMPUTE_WH
             SCHEDULE = 'USING CRON 0 10 1 * * Asia/Tokyo'  -- 毎月1日の午前10時に実行
         AS
-            CALL practice.ml.training();
+            CALL training();
         """
         session.sql(create_task_sql).collect()
         logger.info("Task created successfully")

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -1,0 +1,18 @@
+import os
+from src.utils.config import load_config
+
+config = load_config()
+
+# Snowflake関連の定数
+DATABASE_DEV = config["data"]["snowflake"]["database_dev"]
+SCHEMA = config["data"]["snowflake"]["schema"]
+DATASET = config["data"]["snowflake"]["dataset_table"]
+SOURCE = config["data"]["snowflake"]["source_table"]
+
+CATEGORICAL_FEATURES = config["data"]["features"]["categorical"]
+NUMERICAL_FEATURES = config["data"]["features"]["numeric"]
+TARGET = config["data"]["target"]
+
+# ディレクトリパス関連の定数
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+IMPORTS_DIR = os.path.join(BASE_DIR, "src")

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -1,4 +1,5 @@
 import os
+
 from src.utils.config import load_config
 
 config = load_config()

--- a/tests/data/test_loader.py
+++ b/tests/data/test_loader.py
@@ -1,7 +1,11 @@
 import pandas as pd
 import pytest
 
-from src.data.loader import fetch_training_dataset, fetch_prediction_dataset, fetch_test_dataset
+from src.data.loader import (
+    fetch_prediction_dataset,
+    fetch_test_dataset,
+    fetch_training_dataset,
+)
 from src.utils.config import load_config
 
 config = load_config()
@@ -51,7 +55,9 @@ def test_fetch_training_dataset(mock_snowflake_session, mocker):
     sql_query = mock_snowflake_session.sql.call_args[0][0]
     period_months = config["data"]["period"]["months"]
     expected_end_date = mock_now.strftime("%Y-%m-%d")
-    expected_start_date = (mock_now - pd.DateOffset(months=period_months)).strftime("%Y-%m-%d")
+    expected_start_date = (mock_now - pd.DateOffset(months=period_months)).strftime(
+        "%Y-%m-%d"
+    )
     assert f"BETWEEN '{expected_start_date}' AND '{expected_end_date}'" in sql_query
 
 
@@ -59,7 +65,9 @@ def test_fetch_prediction_dataset(mock_snowflake_session):
     """推論用データセット取得のテスト"""
     # 実行
     prediction_date = "2024-12-01"
-    df = fetch_prediction_dataset(mock_snowflake_session, prediction_date=prediction_date)
+    df = fetch_prediction_dataset(
+        mock_snowflake_session, prediction_date=prediction_date
+    )
 
     # アサーション
     assert df is not None
@@ -184,7 +192,7 @@ def test_fetch_test_dataset(mock_snowflake_session, mocker):
     # SQLクエリにテスト用の日付条件が含まれていることを確認
     sql_query = mock_snowflake_session.sql.call_args[0][0]
     expected_start_date = "2025-01-31"  # モデル作成日の翌日
-    expected_end_date = "2025-02-13"    # モデル作成日から14日後
+    expected_end_date = "2025-02-13"  # モデル作成日から14日後
     assert f"BETWEEN '{expected_start_date}' AND '{expected_end_date}'" in sql_query
 
 
@@ -193,7 +201,7 @@ def test_fetch_test_dataset_error(mocker):
     # エラーを発生させるモックセッション
     error_session = mocker.Mock()
     error_session.sql.side_effect = Exception("Database connection failed")
-    
+
     # モデルバージョンのモック
     mock_model_version = mocker.Mock()
     mock_model_version.version_name = "V_250130_121116"

--- a/tests/data/test_loader.py
+++ b/tests/data/test_loader.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from src.data.loader import fetch_dataset
+from src.data.loader import fetch_training_dataset, fetch_prediction_dataset
 from src.utils.config import load_config
 
 config = load_config()
@@ -34,14 +34,14 @@ def mock_snowflake_session(mocker):
     return session
 
 
-def test_fetch_dataset_training_mode(mock_snowflake_session, mocker):
-    """学習モードでのデータ取得テスト"""
+def test_fetch_training_dataset(mock_snowflake_session, mocker):
+    """学習用データセット取得のテスト"""
     # 現在時刻をモック
     mock_now = pd.Timestamp("2024-03-15")
     mocker.patch("pandas.Timestamp.now", return_value=mock_now)
 
     # 実行
-    df = fetch_dataset(mock_snowflake_session, is_training=True)
+    df = fetch_training_dataset(mock_snowflake_session)
 
     # アサーション
     assert df is not None
@@ -51,19 +51,15 @@ def test_fetch_dataset_training_mode(mock_snowflake_session, mocker):
     sql_query = mock_snowflake_session.sql.call_args[0][0]
     period_months = config["data"]["period"]["months"]
     expected_end_date = mock_now.strftime("%Y-%m-%d")
-    expected_start_date = (mock_now - pd.DateOffset(months=period_months)).strftime(
-        "%Y-%m-%d"
-    )
+    expected_start_date = (mock_now - pd.DateOffset(months=period_months)).strftime("%Y-%m-%d")
     assert f"BETWEEN '{expected_start_date}' AND '{expected_end_date}'" in sql_query
 
 
-def test_fetch_dataset_inference_mode(mock_snowflake_session):
-    """推論モードでのデータ取得テスト"""
+def test_fetch_prediction_dataset(mock_snowflake_session):
+    """推論用データセット取得のテスト"""
     # 実行
     prediction_date = "2024-12-01"
-    df = fetch_dataset(
-        mock_snowflake_session, is_training=False, prediction_date=prediction_date
-    )
+    df = fetch_prediction_dataset(mock_snowflake_session, prediction_date=prediction_date)
 
     # アサーション
     assert df is not None
@@ -74,14 +70,32 @@ def test_fetch_dataset_inference_mode(mock_snowflake_session):
     assert f"SESSION_DATE = '{prediction_date}'" in sql_query
 
 
-def test_fetch_dataset_columns(mock_snowflake_session):
+def test_fetch_dataset_columns(mock_snowflake_session, mocker):
     """取得するカラムの確認テスト"""
-    # 実行
-    df = fetch_dataset(mock_snowflake_session, is_training=True)
+    # モックデータにUIDカラムを追加
+    mock_data = pd.DataFrame(
+        {
+            "UID": ["1"] * 5,  # UIDカラムを追加
+            **{
+                str(col): ["A"] * 5 for col in config["data"]["features"]["categorical"]
+            },
+            **{str(col): [1.0] * 5 for col in config["data"]["features"]["numeric"]},
+            str(config["data"]["target"]): [0, 1, 0, 1, 0],
+        }
+    )
 
-    # 期待されるカラム（リストを展開して結合）
+    # モックの戻り値を更新
+    query_result = mocker.Mock()
+    query_result.to_pandas.return_value = mock_data
+    mock_snowflake_session.sql.return_value = query_result
+
+    # 実行（学習用データセットで確認）
+    df = fetch_training_dataset(mock_snowflake_session)
+
+    # 期待されるカラム
     expected_columns = (
-        [str(col) for col in config["data"]["features"]["categorical"]]
+        ["UID"]
+        + [str(col) for col in config["data"]["features"]["categorical"]]
         + [str(col) for col in config["data"]["features"]["numeric"]]
         + [str(config["data"]["target"])]
     )
@@ -90,29 +104,42 @@ def test_fetch_dataset_columns(mock_snowflake_session):
     assert set(df.columns) == set(expected_columns)
 
 
-def test_fetch_dataset_error_handling(mocker):
-    """エラーハンドリングのテスト"""
+def test_fetch_training_dataset_error(mocker):
+    """学習用データセット取得時のエラーハンドリングテスト"""
     # エラーを発生させるモックセッション
     error_session = mocker.Mock()
     error_session.sql.side_effect = Exception("Database connection failed")
 
     # エラーが発生することを確認
     with pytest.raises(RuntimeError) as exc_info:
-        fetch_dataset(error_session, is_training=True)
+        fetch_training_dataset(error_session)
 
-    assert "Error occurred during dataset retrieval" in str(exc_info.value)
+    assert "Error occurred during training dataset retrieval" in str(exc_info.value)
 
 
-def test_fetch_dataset_inference_mode_without_date(mock_snowflake_session):
-    """prediction_dateなしで推論モードを実行した場合のテスト"""
+def test_fetch_prediction_dataset_error(mocker):
+    """推論用データセット取得時のエラーハンドリングテスト"""
+    # エラーを発生させるモックセッション
+    error_session = mocker.Mock()
+    error_session.sql.side_effect = Exception("Database connection failed")
+
+    # エラーが発生することを確認
     with pytest.raises(RuntimeError) as exc_info:
-        fetch_dataset(mock_snowflake_session, is_training=False, prediction_date=None)
+        fetch_prediction_dataset(error_session, prediction_date="2024-12-01")
+
+    assert "Error occurred during prediction dataset retrieval" in str(exc_info.value)
+
+
+def test_fetch_prediction_dataset_without_date(mock_snowflake_session):
+    """prediction_dateなしで推論用データセット取得を実行した場合のテスト"""
+    with pytest.raises(RuntimeError) as exc_info:
+        fetch_prediction_dataset(mock_snowflake_session, prediction_date=None)
 
     assert "prediction_date is required for inference" in str(exc_info.value)
 
 
-def test_fetch_dataset_empty_result(mocker):
-    """空のデータセットが返された場合のテスト"""
+def test_fetch_empty_training_dataset(mocker):
+    """空の学習用データセットが返された場合のテスト"""
     # 空のデータフレームを返すモックセッション
     empty_session = mocker.Mock()
     empty_result = mocker.Mock()
@@ -121,6 +148,21 @@ def test_fetch_dataset_empty_result(mocker):
 
     # エラーが発生することを確認
     with pytest.raises(RuntimeError) as exc_info:
-        fetch_dataset(empty_session, is_training=True)
+        fetch_training_dataset(empty_session)
 
-    assert "No data found for the specified period" in str(exc_info.value)
+    assert "Error occurred during training dataset retrieval" in str(exc_info.value)
+
+
+def test_fetch_empty_prediction_dataset(mocker):
+    """空の推論用データセットが返された場合のテスト"""
+    # 空のデータフレームを返すモックセッション
+    empty_session = mocker.Mock()
+    empty_result = mocker.Mock()
+    empty_result.to_pandas.return_value = pd.DataFrame()
+    empty_session.sql.return_value = empty_result
+
+    # エラーが発生することを確認
+    with pytest.raises(RuntimeError) as exc_info:
+        fetch_prediction_dataset(empty_session, prediction_date="2024-12-01")
+
+    assert "Error occurred during prediction dataset retrieval" in str(exc_info.value)

--- a/tests/models/test_predictor.py
+++ b/tests/models/test_predictor.py
@@ -4,7 +4,7 @@ import pytest
 from snowflake.ml.model import ModelVersion
 from snowflake.ml.registry import Registry
 
-from src.models.predictor import load_latest_model_version, predict
+from src.models.predictor import load_latest_model_version, load_default_model_version, predict_proba, predict_label
 
 
 @pytest.fixture
@@ -12,23 +12,12 @@ def mock_registry(mocker):
     """Registry モックを作成するフィクスチャ"""
     mock_registry = mocker.Mock(spec=Registry)
 
-    # show_models の戻り値を設定
-    mock_models_df = pd.DataFrame(
-        {"name": ["model_1", "model_2"], "created_on": ["2024-03-15", "2024-03-14"]}
-    )
-    mock_registry.show_models.return_value = mock_models_df
-
     # get_model の戻り値を設定
     mock_model_ref = mocker.Mock()
     mock_model_version = mocker.Mock(spec=ModelVersion)
 
-    # show_versions の戻り値を設定
-    mock_versions_df = pd.DataFrame(
-        {"name": ["250315", "250314"], "created_on": ["2025-03-15", "2025-03-14"]}
-    )
-    mock_model_ref.show_versions.return_value = mock_versions_df
-
-    mock_model_ref.version.return_value = mock_model_version
+    mock_model_ref.last.return_value = mock_model_version
+    mock_model_ref.default = mock_model_version
     mock_registry.get_model.return_value = mock_model_ref
 
     return mock_registry
@@ -45,19 +34,33 @@ def test_load_latest_model_version(mocker, mock_registry):
 
     # アサーション
     assert isinstance(model_version, mocker.Mock)
-    mock_registry.show_models.assert_called_once()
-    mock_registry.get_model.assert_called_once_with("model_1")
-
-    # show_versions が呼ばれたことを確認
+    mock_registry.get_model.assert_called_once_with("random_forest")
+    
+    # last メソッドが呼ばれたことを確認
     model_ref = mock_registry.get_model.return_value
-    model_ref.show_versions.assert_called_once()
-
-    # 最新バージョンで version が呼ばれたことを確認
-    model_ref.version.assert_called_once_with("250315")
+    model_ref.last.assert_called_once()
 
 
-def test_predict(mocker):
-    """predict のテスト"""
+def test_load_default_model_version(mocker, mock_registry):
+    """load_default_model_version のテスト"""
+    # Registry クラスのモックを設定
+    mocker.patch("src.models.predictor.Registry", return_value=mock_registry)
+
+    # テスト実行
+    session = mocker.Mock()
+    model_version = load_default_model_version(session)
+
+    # アサーション
+    assert isinstance(model_version, mocker.Mock)
+    mock_registry.get_model.assert_called_once_with("random_forest")
+    
+    # default プロパティにアクセスしたことを確認
+    model_ref = mock_registry.get_model.return_value
+    assert model_ref.default == model_version
+
+
+def test_predict_proba(mocker):
+    """predict_proba のテスト"""
     # テストデータ作成
     features = pd.DataFrame({"feature1": [1, 2, 3], "feature2": [0.1, 0.2, 0.3]})
 
@@ -69,10 +72,32 @@ def test_predict(mocker):
     mock_model_version.run.return_value = mock_predictions
 
     # テスト実行
-    predictions = predict(features, mock_model_version)
+    predictions = predict_proba(features, mock_model_version)
 
     # アサーション
     assert isinstance(predictions, np.ndarray)
     assert len(predictions) == 3
     np.testing.assert_array_almost_equal(predictions, np.array([0.8, 0.7, 0.6]))
-    mock_model_version.run.assert_called_once()
+    mock_model_version.run.assert_called_once_with(features, function_name="predict_proba")
+
+
+def test_predict_label(mocker):
+    """predict_label のテスト"""
+    # テストデータ作成
+    features = pd.DataFrame({"feature1": [1, 2, 3], "feature2": [0.1, 0.2, 0.3]})
+
+    # ModelVersion モックの作成
+    mock_model_version = mocker.Mock(spec=ModelVersion)
+    mock_predictions = pd.DataFrame(
+        {"output_feature_0": [1, 0, 1]}
+    )
+    mock_model_version.run.return_value = mock_predictions
+
+    # テスト実行
+    predictions = predict_label(features, mock_model_version)
+
+    # アサーション
+    assert isinstance(predictions, np.ndarray)
+    assert len(predictions) == 3
+    np.testing.assert_array_almost_equal(predictions, np.array([1, 0, 1]))
+    mock_model_version.run.assert_called_once_with(features, function_name="predict")

--- a/tests/models/test_predictor.py
+++ b/tests/models/test_predictor.py
@@ -4,7 +4,12 @@ import pytest
 from snowflake.ml.model import ModelVersion
 from snowflake.ml.registry import Registry
 
-from src.models.predictor import load_latest_model_version, load_default_model_version, predict_proba, predict_label
+from src.models.predictor import (
+    load_default_model_version,
+    load_latest_model_version,
+    predict_label,
+    predict_proba,
+)
 
 
 @pytest.fixture
@@ -35,7 +40,7 @@ def test_load_latest_model_version(mocker, mock_registry):
     # アサーション
     assert isinstance(model_version, mocker.Mock)
     mock_registry.get_model.assert_called_once_with("random_forest")
-    
+
     # last メソッドが呼ばれたことを確認
     model_ref = mock_registry.get_model.return_value
     model_ref.last.assert_called_once()
@@ -53,7 +58,7 @@ def test_load_default_model_version(mocker, mock_registry):
     # アサーション
     assert isinstance(model_version, mocker.Mock)
     mock_registry.get_model.assert_called_once_with("random_forest")
-    
+
     # default プロパティにアクセスしたことを確認
     model_ref = mock_registry.get_model.return_value
     assert model_ref.default == model_version
@@ -78,7 +83,9 @@ def test_predict_proba(mocker):
     assert isinstance(predictions, np.ndarray)
     assert len(predictions) == 3
     np.testing.assert_array_almost_equal(predictions, np.array([0.8, 0.7, 0.6]))
-    mock_model_version.run.assert_called_once_with(features, function_name="predict_proba")
+    mock_model_version.run.assert_called_once_with(
+        features, function_name="predict_proba"
+    )
 
 
 def test_predict_label(mocker):
@@ -88,9 +95,7 @@ def test_predict_label(mocker):
 
     # ModelVersion モックの作成
     mock_model_version = mocker.Mock(spec=ModelVersion)
-    mock_predictions = pd.DataFrame(
-        {"output_feature_0": [1, 0, 1]}
-    )
+    mock_predictions = pd.DataFrame({"output_feature_0": [1, 0, 1]})
     mock_model_version.run.return_value = mock_predictions
 
     # テスト実行

--- a/tests/pipelines/test_sproc_offline_testing.py
+++ b/tests/pipelines/test_sproc_offline_testing.py
@@ -1,0 +1,99 @@
+import pytest
+import pandas as pd
+import numpy as np
+from snowflake.snowpark import Session
+
+from src.pipelines.sproc_offline_testing import sproc_offline_testing
+
+
+@pytest.mark.parametrize("challenger_better", [True, False])
+def test_sproc_offline_testing_success(mocker, challenger_better):
+    """
+    sproc_offline_testingの正常系テスト
+    
+    Args:
+        mocker: pytest-mockのフィクスチャ
+        challenger_better: チャレンジャーモデルが優れているかどうかのフラグ
+    """
+    # モックセッションの作成
+    mock_session = mocker.Mock(spec=Session)
+
+    # モデルバージョンのモック
+    champion_model = mocker.Mock()
+    champion_model.version = "V_250130_121116"
+    
+    challenger_model = mocker.Mock()
+    challenger_model.version = "V_250202_121116"
+
+    # テストデータの準備
+    test_data = pd.DataFrame({
+        'feature1': np.random.rand(100),
+        'feature2': np.random.rand(100),
+        'REVENUE': np.random.choice([0, 1], size=100),
+        'UID': range(100)
+    })
+
+    # 各依存関数のモック化
+    mock_load_default = mocker.patch('src.pipelines.sproc_offline_testing.load_default_model_version')
+    mock_load_default.return_value = champion_model
+
+    mock_load_latest = mocker.patch('src.pipelines.sproc_offline_testing.load_latest_model_version')
+    mock_load_latest.return_value = challenger_model
+
+    mock_fetch_test = mocker.patch('src.pipelines.sproc_offline_testing.fetch_test_dataset')
+    mock_fetch_test.return_value = test_data
+
+    mock_predict_proba = mocker.patch('src.pipelines.sproc_offline_testing.predict_proba')
+    mock_predict_proba.return_value = np.random.rand(100)
+
+    mock_predict_label = mocker.patch('src.pipelines.sproc_offline_testing.predict_label')
+    mock_predict_label.return_value = np.random.randint(0, 2, 100)
+
+    mock_calc_metrics = mocker.patch('src.pipelines.sproc_offline_testing.calc_evaluation_metrics')
+    if challenger_better:
+        challenger_scores = {"PR-AUC": 0.9}
+        champion_scores = {"PR-AUC": 0.8}
+    else:
+        challenger_scores = {"PR-AUC": 0.8}
+        champion_scores = {"PR-AUC": 0.9}
+    mock_calc_metrics.side_effect = [challenger_scores, champion_scores]
+
+    # Registryのモック
+    mock_registry = mocker.patch('src.pipelines.sproc_offline_testing.Registry')
+    mock_registry_instance = mocker.Mock()
+    mock_registry.return_value = mock_registry_instance
+    mock_model = mocker.Mock()
+    mock_registry_instance.get_model.return_value = mock_model
+
+    # テスト実行
+    result = sproc_offline_testing(mock_session)
+
+    # アサーション
+    assert result == 1
+    mock_load_default.assert_called_once_with(mock_session)
+    mock_load_latest.assert_called_once_with(mock_session)
+    mock_fetch_test.assert_called_once_with(mock_session, challenger_model)
+
+    if challenger_better:
+        # チャレンジャーモデルが優れている場合、デフォルトバージョンが更新されることを確認
+        mock_registry_instance.get_model.assert_called_once_with("random_forest")
+        assert mock_model.default == challenger_model
+    else:
+        # チャレンジャーモデルが劣っている場合、デフォルトバージョンが更新されないことを確認
+        mock_registry_instance.get_model.assert_not_called()
+
+
+def test_sproc_offline_testing_error(mocker):
+    """
+    エラー発生時のテスト
+    """
+    # モックセッションの作成
+    mock_session = mocker.Mock(spec=Session)
+
+    # load_default_model_versionでエラーを発生させる
+    mock_load_default = mocker.patch('src.pipelines.sproc_offline_testing.load_default_model_version')
+    mock_load_default.side_effect = Exception("テストエラー")
+
+    # エラーが発生することを確認
+    with pytest.raises(Exception, match="テストエラー"):
+        sproc_offline_testing(mock_session)

--- a/tests/pipelines/test_sproc_offline_testing.py
+++ b/tests/pipelines/test_sproc_offline_testing.py
@@ -1,6 +1,6 @@
-import pytest
-import pandas as pd
 import numpy as np
+import pandas as pd
+import pytest
 from snowflake.snowpark import Session
 
 from src.pipelines.sproc_offline_testing import sproc_offline_testing
@@ -10,7 +10,7 @@ from src.pipelines.sproc_offline_testing import sproc_offline_testing
 def test_sproc_offline_testing_success(mocker, challenger_better):
     """
     sproc_offline_testingの正常系テスト
-    
+
     Args:
         mocker: pytest-mockのフィクスチャ
         challenger_better: チャレンジャーモデルが優れているかどうかのフラグ
@@ -21,35 +21,49 @@ def test_sproc_offline_testing_success(mocker, challenger_better):
     # モデルバージョンのモック
     champion_model = mocker.Mock()
     champion_model.version = "V_250130_121116"
-    
+
     challenger_model = mocker.Mock()
     challenger_model.version = "V_250202_121116"
 
     # テストデータの準備
-    test_data = pd.DataFrame({
-        'feature1': np.random.rand(100),
-        'feature2': np.random.rand(100),
-        'REVENUE': np.random.choice([0, 1], size=100),
-        'UID': range(100)
-    })
+    test_data = pd.DataFrame(
+        {
+            "feature1": np.random.rand(100),
+            "feature2": np.random.rand(100),
+            "REVENUE": np.random.choice([0, 1], size=100),
+            "UID": range(100),
+        }
+    )
 
     # 各依存関数のモック化
-    mock_load_default = mocker.patch('src.pipelines.sproc_offline_testing.load_default_model_version')
+    mock_load_default = mocker.patch(
+        "src.pipelines.sproc_offline_testing.load_default_model_version"
+    )
     mock_load_default.return_value = champion_model
 
-    mock_load_latest = mocker.patch('src.pipelines.sproc_offline_testing.load_latest_model_version')
+    mock_load_latest = mocker.patch(
+        "src.pipelines.sproc_offline_testing.load_latest_model_version"
+    )
     mock_load_latest.return_value = challenger_model
 
-    mock_fetch_test = mocker.patch('src.pipelines.sproc_offline_testing.fetch_test_dataset')
+    mock_fetch_test = mocker.patch(
+        "src.pipelines.sproc_offline_testing.fetch_test_dataset"
+    )
     mock_fetch_test.return_value = test_data
 
-    mock_predict_proba = mocker.patch('src.pipelines.sproc_offline_testing.predict_proba')
+    mock_predict_proba = mocker.patch(
+        "src.pipelines.sproc_offline_testing.predict_proba"
+    )
     mock_predict_proba.return_value = np.random.rand(100)
 
-    mock_predict_label = mocker.patch('src.pipelines.sproc_offline_testing.predict_label')
+    mock_predict_label = mocker.patch(
+        "src.pipelines.sproc_offline_testing.predict_label"
+    )
     mock_predict_label.return_value = np.random.randint(0, 2, 100)
 
-    mock_calc_metrics = mocker.patch('src.pipelines.sproc_offline_testing.calc_evaluation_metrics')
+    mock_calc_metrics = mocker.patch(
+        "src.pipelines.sproc_offline_testing.calc_evaluation_metrics"
+    )
     if challenger_better:
         challenger_scores = {"PR-AUC": 0.9}
         champion_scores = {"PR-AUC": 0.8}
@@ -59,7 +73,7 @@ def test_sproc_offline_testing_success(mocker, challenger_better):
     mock_calc_metrics.side_effect = [challenger_scores, champion_scores]
 
     # Registryのモック
-    mock_registry = mocker.patch('src.pipelines.sproc_offline_testing.Registry')
+    mock_registry = mocker.patch("src.pipelines.sproc_offline_testing.Registry")
     mock_registry_instance = mocker.Mock()
     mock_registry.return_value = mock_registry_instance
     mock_model = mocker.Mock()
@@ -91,7 +105,9 @@ def test_sproc_offline_testing_error(mocker):
     mock_session = mocker.Mock(spec=Session)
 
     # load_default_model_versionでエラーを発生させる
-    mock_load_default = mocker.patch('src.pipelines.sproc_offline_testing.load_default_model_version')
+    mock_load_default = mocker.patch(
+        "src.pipelines.sproc_offline_testing.load_default_model_version"
+    )
     mock_load_default.side_effect = Exception("テストエラー")
 
     # エラーが発生することを確認

--- a/tests/pipelines/test_sproc_prediction.py
+++ b/tests/pipelines/test_sproc_prediction.py
@@ -13,7 +13,7 @@ def test_sproc_prediction_success(mocker):
     test_data = pd.DataFrame({"UID": [1, 2], "FEATURE1": [0.1, 0.2]})
 
     # 各依存関数のモック化
-    mock_fetch = mocker.patch("src.pipelines.sproc_prediction.fetch_dataset")
+    mock_fetch = mocker.patch("src.pipelines.sproc_prediction.fetch_prediction_dataset")
     mock_fetch.return_value = test_data
 
     # モデルバージョンのモック
@@ -40,7 +40,7 @@ def test_sproc_prediction_success(mocker):
     # アサーション
     assert result == 1
     mock_fetch.assert_called_once_with(
-        mock_session, is_training=False, prediction_date="2024-03-20"
+        mock_session, prediction_date="2024-03-20"
     )
     mock_load_model.assert_called_once_with(mock_session)
     mock_predict.assert_called_once()
@@ -49,11 +49,11 @@ def test_sproc_prediction_success(mocker):
 
 def test_sproc_prediction_fetch_dataset_returns_none(mocker):
     mock_session = mocker.Mock(spec=Session)
-    mock_fetch = mocker.patch("src.pipelines.sproc_prediction.fetch_dataset")
+    mock_fetch = mocker.patch("src.pipelines.sproc_prediction.fetch_prediction_dataset")
     mock_fetch.return_value = None
 
     with pytest.raises(ValueError, match="Failed to fetch dataset"):
         sproc_prediction(mock_session, "2024-03-20")
     mock_fetch.assert_called_once_with(
-        mock_session, is_training=False, prediction_date="2024-03-20"
+        mock_session, prediction_date="2024-03-20"
     )

--- a/tests/pipelines/test_sproc_prediction.py
+++ b/tests/pipelines/test_sproc_prediction.py
@@ -27,7 +27,7 @@ def test_sproc_prediction_success(mocker):
     mock_load_model.return_value = mock_model_version
 
     # 予測値のモック
-    mock_predict = mocker.patch("src.pipelines.sproc_prediction.predict")
+    mock_predict = mocker.patch("src.pipelines.sproc_prediction.predict_proba")
     mock_predict.return_value = [0.8, 0.9]
 
     mock_upload = mocker.patch(

--- a/tests/pipelines/test_sproc_prediction.py
+++ b/tests/pipelines/test_sproc_prediction.py
@@ -39,9 +39,7 @@ def test_sproc_prediction_success(mocker):
 
     # アサーション
     assert result == 1
-    mock_fetch.assert_called_once_with(
-        mock_session, prediction_date="2024-03-20"
-    )
+    mock_fetch.assert_called_once_with(mock_session, prediction_date="2024-03-20")
     mock_load_model.assert_called_once_with(mock_session)
     mock_predict.assert_called_once()
     mock_upload.assert_called_once()
@@ -54,6 +52,4 @@ def test_sproc_prediction_fetch_dataset_returns_none(mocker):
 
     with pytest.raises(ValueError, match="Failed to fetch dataset"):
         sproc_prediction(mock_session, "2024-03-20")
-    mock_fetch.assert_called_once_with(
-        mock_session, prediction_date="2024-03-20"
-    )
+    mock_fetch.assert_called_once_with(mock_session, prediction_date="2024-03-20")

--- a/tests/pipelines/test_sproc_training.py
+++ b/tests/pipelines/test_sproc_training.py
@@ -11,14 +11,12 @@ def test_sproc_training_success(mocker):
     mock_session = mocker.Mock(spec=Session)
 
     # 各依存関数のモック化
-    mock_fetch = mocker.patch("src.pipelines.sproc_training.fetch_dataset")
-    mock_fetch.return_value = pd.DataFrame(
-        {
-            "UID": ["user1", "user2"],
-            "FEATURE1": [0.1, 0.2],
-            "REVENUE": [0, 1],  # TARGETをREVENUEに変更
-        }
-    )
+    mock_fetch = mocker.patch("src.pipelines.sproc_training.fetch_training_dataset")
+    mock_fetch.return_value = pd.DataFrame({
+        "UID": ["user1", "user2"],
+        "FEATURE1": [0.1, 0.2],
+        "REVENUE": [0, 1],
+    })
 
     mock_split = mocker.patch("src.pipelines.sproc_training.split_data")
     mock_split.return_value = (
@@ -50,7 +48,7 @@ def test_sproc_training_success(mocker):
 
 def test_sproc_training_fetch_dataset_returns_none(mocker):
     mock_session = mocker.Mock(spec=Session)
-    mock_fetch = mocker.patch("src.pipelines.sproc_training.fetch_dataset")
+    mock_fetch = mocker.patch("src.pipelines.sproc_training.fetch_training_dataset")
     mock_fetch.return_value = None
 
     with pytest.raises(ValueError, match="Failed to fetch dataset"):

--- a/tests/pipelines/test_sproc_training.py
+++ b/tests/pipelines/test_sproc_training.py
@@ -12,11 +12,13 @@ def test_sproc_training_success(mocker):
 
     # 各依存関数のモック化
     mock_fetch = mocker.patch("src.pipelines.sproc_training.fetch_training_dataset")
-    mock_fetch.return_value = pd.DataFrame({
-        "UID": ["user1", "user2"],
-        "FEATURE1": [0.1, 0.2],
-        "REVENUE": [0, 1],
-    })
+    mock_fetch.return_value = pd.DataFrame(
+        {
+            "UID": ["user1", "user2"],
+            "FEATURE1": [0.1, 0.2],
+            "REVENUE": [0, 1],
+        }
+    )
 
     mock_split = mocker.patch("src.pipelines.sproc_training.split_data")
     mock_split.return_value = (


### PR DESCRIPTION
① 以下の仕様でオフラインテストを行う sproc, task を追加

- モデルの読み込み
  - Championモデル：現在のデフォルトバージョン
  - Challengerモデル：最新バージョン
- 評価プロセス
  - テストデータセット : Challengerモデルの学習日の翌日 ~ 14日後まで
  - 両モデルで予測（確率値と予測ラベル）し、評価指標の計算
- モデル比較とアクション
  - PR-AUC（Precision-Recall曲線下面積）を比較
    - Challengerの方が優れている場合：デフォルトバージョンをChallengerに更新
    - Championの方が優れている場合：変更なし
- スケジューリング: 毎月15日のAM10:00(JST) 

② リファクタ
- 各ファイルでload_configから読み込んでいた定数を utils/constants.py 殻に変更
- fetch_dataset を training, prediction, test それぞれに関数を分割